### PR TITLE
feat(mapper_utils): add onError callback to mapAsync helpers [CU-86c9…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.7.1
+## 1.1.0
+- Add optional `onError` callback (`MapOnError<T, S>`) to `MapUtils.mapAsync`, `MapUtils.mapAsyncInIsolate`, and the `MapAsync<T>` extension methods (`mapAsync`, `mapAsyncInIsolate`). When provided, errors thrown while running the mapper (or while dispatching the isolate task) are caught, logged (subject to `printError`), and the value returned by `onError` is returned instead of rethrowing. If `onError` is `null` (the default), the previous behavior is preserved and errors are rethrown after logging. This is a **non-breaking, additive** change.
+- Clean up the redundant `try/catch(e){rethrow}` wrapper in the private `_mapAsync` isolate entry point.
+- Added tests for `mapper_utilities.dart`.
+
 ## 1.0.0
 - Added support for nested JSON keys using dot notation (e.g., `'data.user.name'`) in all `safe_json_convert` functions.
 - Introduced `toEnum`/`asEnum` and `toUri`/`asUri` safe conversion functions.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -212,18 +212,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -302,7 +302,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.1.0"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -432,10 +432,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.8"
   vector_math:
     dependency: transitive
     description:

--- a/lib/src/utils/mapper_utilities.dart
+++ b/lib/src/utils/mapper_utilities.dart
@@ -5,29 +5,40 @@ import 'package:playx_core/playx_core.dart';
 
 typedef Mapper<T, S> = FutureOr<S> Function(T data);
 
+/// Callback used by [MapUtils] helpers to recover from an error thrown while
+/// mapping [data]. The value returned by this callback is returned to the
+/// caller instead of rethrowing the error.
+typedef MapOnError<T, S> = S Function(T data, Object error, StackTrace stack);
+
 Future<S> _mapAsync<T, S>(List arguments) async {
-  try {
-    final data = arguments[0] as T;
-    final mapper = arguments[1] as Mapper<T, S>;
-    return await mapper(data);
-  } catch (e) {
-    rethrow;
-  }
+  final data = arguments[0] as T;
+  final mapper = arguments[1] as Mapper<T, S>;
+  return await mapper(data);
 }
 
 class MapUtils {
   MapUtils._();
 
   /// Maps the value of the future to a new value.
-  static Future<S> mapAsync<T, S>(
-      {required T data,
-      required Mapper<T, S> mapper,
-      bool printError = kDebugMode}) async {
+  ///
+  /// If [onError] is provided, any error thrown while running [mapper] is
+  /// caught, logged when [printError] is `true`, and the value returned by
+  /// [onError] is returned instead of rethrowing. If [onError] is `null`
+  /// (the default), the error is rethrown after logging.
+  static Future<S> mapAsync<T, S>({
+    required T data,
+    required Mapper<T, S> mapper,
+    bool printError = kDebugMode,
+    MapOnError<T, S>? onError,
+  }) async {
     try {
       return await mapper(data);
     } catch (e, s) {
       if (printError) {
         PlayxCore.logger.error('MapAsync Error', error: e, stackTrace: s);
+      }
+      if (onError != null) {
+        return onError(data, e, s);
       }
       // Handle any errors in the main thread
       rethrow;
@@ -37,11 +48,18 @@ class MapUtils {
   /// Maps the value of the future to a new value in an isolate.
   /// If [useWorkManager] is set to true, it will use [workerManager] to execute the task.
   /// Otherwise, it will use [compute] to execute the task.
+  ///
+  /// If [onError] is provided, any error thrown while running [mapper] (or
+  /// while dispatching the task to the isolate) is caught, logged when
+  /// [printError] is `true`, and the value returned by [onError] is returned
+  /// instead of rethrowing. If [onError] is `null` (the default), the error is
+  /// rethrown after logging.
   static Future<S> mapAsyncInIsolate<T, S>({
     required T data,
     required Mapper<T, S> mapper,
     bool useWorkManager = true,
     bool printError = kDebugMode,
+    MapOnError<T, S>? onError,
   }) async {
     try {
       final res = useWorkManager
@@ -53,6 +71,9 @@ class MapUtils {
         PlayxCore.logger
             .error('MapAsyncInIsolate Error', error: e, stackTrace: s);
       }
+      if (onError != null) {
+        return onError(data, e, s);
+      }
       // Handle errors occurring in the isolate
       rethrow;
     }
@@ -61,23 +82,41 @@ class MapUtils {
 
 extension MapAsync<T> on T {
   /// Maps the value of the T to a new value.
+  ///
+  /// If [onError] is provided, any error thrown while running [mapper] is
+  /// caught, logged when [printError] is `true`, and the value returned by
+  /// [onError] is returned instead of rethrowing. If [onError] is `null`
+  /// (the default), the error is rethrown after logging.
   Future<S> mapAsync<S>({
     required Mapper<T, S> mapper,
     bool printError = kDebugMode,
+    MapOnError<T, S>? onError,
   }) =>
-      MapUtils.mapAsync(data: this, mapper: mapper, printError: printError);
+      MapUtils.mapAsync(
+          data: this,
+          mapper: mapper,
+          printError: printError,
+          onError: onError);
 
   //// Maps the value of the [T] to a new value in an isolate.
   /// If [useWorkManager] is set to true, it will use [WorkerManager] to execute the task.
   /// Otherwise, it will use [compute] to execute the task.
+  ///
+  /// If [onError] is provided, any error thrown while running [mapper] (or
+  /// while dispatching the task to the isolate) is caught, logged when
+  /// [printError] is `true`, and the value returned by [onError] is returned
+  /// instead of rethrowing. If [onError] is `null` (the default), the error is
+  /// rethrown after logging.
   Future<S> mapAsyncInIsolate<S>({
     required Mapper<T, S> mapper,
     bool useWorkManager = true,
     bool printError = kDebugMode,
+    MapOnError<T, S>? onError,
   }) =>
       MapUtils.mapAsyncInIsolate(
           data: this,
           mapper: mapper,
           useWorkManager: useWorkManager,
-          printError: printError);
+          printError: printError,
+          onError: onError);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -204,18 +204,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -417,10 +417,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.8"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: playx_core
 description: Core package for playx eco system contains shared classes and utilities.
-version: 1.0.0
+version: 1.1.0
 homepage: https://sourcya.io/
 repository: https://github.com/playx-flutter/playx_core
 issue_tracker: https://github.com/playx-flutter/playx_core/issues

--- a/test/utils/mapper_utilities_test.dart
+++ b/test/utils/mapper_utilities_test.dart
@@ -1,0 +1,173 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playx_core/playx_core.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('MapUtils.mapAsync', () {
+    test('returns the mapped value on success', () async {
+      final result = await MapUtils.mapAsync<int, String>(
+        data: 42,
+        mapper: (n) => 'value:$n',
+      );
+      expect(result, 'value:42');
+    });
+
+    test('supports an async mapper', () async {
+      final result = await MapUtils.mapAsync<int, String>(
+        data: 7,
+        mapper: (n) async => 'async:$n',
+      );
+      expect(result, 'async:7');
+    });
+
+    test('rethrows when the mapper throws and onError is null', () async {
+      expect(
+        () => MapUtils.mapAsync<int, String>(
+          data: 1,
+          mapper: (_) => throw StateError('boom'),
+          printError: false,
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('returns fallback from onError instead of rethrowing', () async {
+      final result = await MapUtils.mapAsync<int, String>(
+        data: 1,
+        mapper: (_) => throw StateError('boom'),
+        printError: false,
+        onError: (data, error, stack) => 'fallback:$data',
+      );
+      expect(result, 'fallback:1');
+    });
+
+    test('onError receives the original data, error and stack trace', () async {
+      Object? capturedError;
+      StackTrace? capturedStack;
+      int? capturedData;
+      await MapUtils.mapAsync<int, String>(
+        data: 9,
+        mapper: (_) => throw ArgumentError('nope'),
+        printError: false,
+        onError: (data, error, stack) {
+          capturedData = data;
+          capturedError = error;
+          capturedStack = stack;
+          return 'recovered';
+        },
+      );
+      expect(capturedData, 9);
+      expect(capturedError, isA<ArgumentError>());
+      expect(capturedStack, isNotNull);
+    });
+  });
+
+  group('MapUtils.mapAsyncInIsolate', () {
+    // Use `compute` (useWorkManager: false) to keep the test isolate-light
+    // and deterministic across CI environments.
+    test('returns the mapped value on success', () async {
+      final result = await MapUtils.mapAsyncInIsolate<int, String>(
+        data: 5,
+        mapper: (n) => 'iso:$n',
+        useWorkManager: false,
+        printError: false,
+      );
+      expect(result, 'iso:5');
+    });
+
+    test('rethrows when the mapper throws and onError is null', () async {
+      expect(
+        () => MapUtils.mapAsyncInIsolate<int, String>(
+          data: 1,
+          mapper: (_) => throw StateError('boom'),
+          useWorkManager: false,
+          printError: false,
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('returns fallback from onError instead of rethrowing', () async {
+      final result = await MapUtils.mapAsyncInIsolate<int, String>(
+        data: 2,
+        mapper: (_) => throw StateError('boom'),
+        useWorkManager: false,
+        printError: false,
+        onError: (data, error, stack) => 'iso-fallback:$data',
+      );
+      expect(result, 'iso-fallback:2');
+    });
+  });
+
+  group('MapAsync<T> extension', () {
+    test('mapAsync returns the mapped value on success', () async {
+      final result = await 10.mapAsync<String>(
+        mapper: (n) => 'ext:$n',
+        printError: false,
+      );
+      expect(result, 'ext:10');
+    });
+
+    test('mapAsync returns fallback via onError instead of rethrowing',
+        () async {
+      final result = await 10.mapAsync<String>(
+        mapper: (_) => throw StateError('boom'),
+        printError: false,
+        onError: (data, error, stack) => 'ext-fallback:$data',
+      );
+      expect(result, 'ext-fallback:10');
+    });
+
+    test('mapAsyncInIsolate returns the mapped value on success', () async {
+      final result = await 3.mapAsyncInIsolate<String>(
+        mapper: (n) => 'iso-ext:$n',
+        useWorkManager: false,
+        printError: false,
+      );
+      expect(result, 'iso-ext:3');
+    });
+
+    test('mapAsyncInIsolate returns fallback via onError instead of rethrowing',
+        () async {
+      final result = await 3.mapAsyncInIsolate<String>(
+        mapper: (_) => throw StateError('boom'),
+        useWorkManager: false,
+        printError: false,
+        onError: (data, error, stack) => 'iso-ext-fallback:$data',
+      );
+      expect(result, 'iso-ext-fallback:3');
+    });
+
+    test('FutureOr mapper is awaited correctly', () async {
+      FutureOr<String> mapper(int n) async => 'future-or:$n';
+      final result = await 8.mapAsync<String>(
+        mapper: mapper,
+        printError: false,
+      );
+      expect(result, 'future-or:8');
+    });
+  });
+
+  group('MapOnError typedef', () {
+    test('is a function that takes data, error and stack and returns S', () {
+      // Compile-time + runtime sanity for the typedef signature.
+      String onError(int data, Object error, StackTrace stack) =>
+          'recovered:$data';
+      expect(onError(1, StateError('x'), StackTrace.empty), 'recovered:1');
+    });
+  });
+
+  group('kDebugMode default', () {
+    test('printError defaults to kDebugMode', () {
+      // Sanity: the default value of printError should match kDebugMode so
+      // errors are logged only in debug builds by default.
+      // (This is enforced by the API signature; here we just assert the
+      // constant is accessible from the same library surface.)
+      expect(kDebugMode, isA<bool>());
+    });
+  });
+}


### PR DESCRIPTION
…ru1bz]

Introduce an optional `onError` callback (`MapOnError<T, S>`) to all `mapAsync`/`mapAsyncInIsolate` methods (both static and extension).

- When provided, errors thrown by the mapper (or isolate dispatch) are caught, logged (subject to `printError`), and the value returned by `onError` is used instead of rethrowing.
- The default behaviour (rethrowing after logging) remains unchanged, making this a fully **non-breaking, additive** change.
- Clean up the redundant `try/catch(e){rethrow}` wrapper in the private `_mapAsync` isolate entry point.
- Add comprehensive tests for `mapper_utilities.dart`.
- Bump version to `1.1.0` and update CHANGELOG accordingly.

ClickUp: CU-86c9ru1bz