### PR TITLE
feat(padding): add EdgeInsets and Padding widget extensions [CU-86c9r…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.1
+- Added **Padding extensions** (`padding_extensions.dart`): `PlayxNumPaddingExtensions` on `num` (`.p`, `.px`, `.py`, `.pAll`, `.pLR`, `.pTB`, `.pZero`, `pSymmetric`, `pOnly`) and `PlayxWidgetPaddingExtensions` on `Widget` (`pAll`, `pSymmetric`, `pOnly`, `pZero`) to easily create `EdgeInsets` and wrap widgets in `Padding`. Helpers return unscaled `EdgeInsets`; apps that need responsive scaling should scale the numeric input (e.g. `16.r.p`).
+
 ## 0.7.1
 ## 1.0.0
 - Added support for nested JSON keys using dot notation (e.g., `'data.user.name'`) in all `safe_json_convert` functions.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -212,18 +212,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -302,7 +302,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.1"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -432,10 +432,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.8"
   vector_math:
     dependency: transitive
     description:

--- a/lib/playx_core.dart
+++ b/lib/playx_core.dart
@@ -15,6 +15,7 @@ export 'src/extensions/date_time_extensions.dart';
 export 'src/extensions/duration_extensions.dart';
 export 'src/extensions/iterable_extensions.dart';
 export 'src/extensions/locale_extensions.dart';
+export 'src/extensions/padding_extensions.dart';
 export 'src/extensions/string_extensions.dart';
 export 'src/models/envs_settings.dart';
 export 'src/models/prefs_settings.dart';

--- a/lib/src/extensions/padding_extensions.dart
+++ b/lib/src/extensions/padding_extensions.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/widgets.dart';
+
+/// Extensions on [num] to easily create [EdgeInsets] for padding.
+///
+/// These helpers return unscaled [EdgeInsets] using the receiver's
+/// [num.toDouble] value. Apps that need responsive scaling should scale the
+/// numeric input before applying the extension, e.g. `16.r.p` when using
+/// `flutter_screenutil`.
+///
+/// ```dart
+/// final padding = 16.p;              // EdgeInsets.all(16)
+/// final hPadding = 8.px;             // EdgeInsets.symmetric(horizontal: 8)
+/// final vPadding = 4.py;             // EdgeInsets.symmetric(vertical: 4)
+/// final mixed = 0.pSymmetric(horizontal: 12, vertical: 6);
+/// final leftOnly = 0.pOnly(left: 10);
+/// ```
+extension PlayxNumPaddingExtensions on num {
+  /// Creates [EdgeInsets.all] with the current value on all sides.
+  EdgeInsets get p => EdgeInsets.all(toDouble());
+
+  /// Creates [EdgeInsets.symmetric] with the current value on the horizontal
+  /// (left and right) sides.
+  EdgeInsets get px => EdgeInsets.symmetric(horizontal: toDouble());
+
+  /// Creates [EdgeInsets.symmetric] with the current value on the vertical
+  /// (top and bottom) sides.
+  EdgeInsets get py => EdgeInsets.symmetric(vertical: toDouble());
+
+  /// Creates [EdgeInsets.all] with the current value on all sides.
+  ///
+  /// Explicit alias of [p] for cases where a named form reads better.
+  EdgeInsets get pAll => EdgeInsets.all(toDouble());
+
+  /// Creates [EdgeInsets.symmetric] with the current value on the left and
+  /// right sides.
+  ///
+  /// Explicit alias of [px].
+  EdgeInsets get pLR => EdgeInsets.symmetric(horizontal: toDouble());
+
+  /// Creates [EdgeInsets.symmetric] with the current value on the top and
+  /// bottom sides.
+  ///
+  /// Explicit alias of [py].
+  EdgeInsets get pTB => EdgeInsets.symmetric(vertical: toDouble());
+
+  /// Creates [EdgeInsets.zero], ignoring the receiver value.
+  ///
+  /// Provided on [num] for API symmetry with the other padding helpers so
+  /// callers can write `0.pZero` or `null.pZero` style code consistently.
+  EdgeInsets get pZero => EdgeInsets.zero;
+
+  /// Creates [EdgeInsets.symmetric] with the given [horizontal] and [vertical]
+  /// values.
+  ///
+  /// ```dart
+  /// final padding = 0.pSymmetric(horizontal: 12, vertical: 6);
+  /// ```
+  EdgeInsets pSymmetric({
+    double horizontal = 0,
+    double vertical = 0,
+  }) =>
+      EdgeInsets.symmetric(horizontal: horizontal, vertical: vertical);
+
+  /// Creates [EdgeInsets.only] with the given per-side values.
+  ///
+  /// ```dart
+  /// final padding = 0.pOnly(left: 10, top: 4);
+  /// ```
+  EdgeInsets pOnly({
+    double left = 0,
+    double top = 0,
+    double right = 0,
+    double bottom = 0,
+  }) =>
+      EdgeInsets.only(
+        left: left,
+        top: top,
+        right: right,
+        bottom: bottom,
+      );
+}
+
+/// Extensions on [Widget] to easily wrap it in a [Padding] widget.
+///
+/// These helpers are thin wrappers around [Padding] for the most common
+/// padding patterns. They return unscaled [EdgeInsets] and do not depend on
+/// any responsive-scaling package.
+///
+/// ```dart
+/// Text('Hello').pAll(16);
+/// Text('Hello').pSymmetric(horizontal: 12, vertical: 6);
+/// Text('Hello').pOnly(left: 10);
+/// ```
+extension PlayxWidgetPaddingExtensions on Widget {
+  /// Wraps this widget in a [Padding] with [EdgeInsets.all] of [value].
+  Widget pAll(double value) => Padding(
+        padding: EdgeInsets.all(value),
+        child: this,
+      );
+
+  /// Wraps this widget in a [Padding] with [EdgeInsets.symmetric] using the
+  /// given [horizontal] and [vertical] values.
+  Widget pSymmetric({
+    double horizontal = 0,
+    double vertical = 0,
+  }) =>
+      Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: horizontal,
+          vertical: vertical,
+        ),
+        child: this,
+      );
+
+  /// Wraps this widget in a [Padding] with [EdgeInsets.only] using the given
+  /// per-side values.
+  Widget pOnly({
+    double left = 0,
+    double top = 0,
+    double right = 0,
+    double bottom = 0,
+  }) =>
+      Padding(
+        padding: EdgeInsets.only(
+          left: left,
+          top: top,
+          right: right,
+          bottom: bottom,
+        ),
+        child: this,
+      );
+
+  /// Wraps this widget in a [Padding] with [EdgeInsets.zero].
+  ///
+  /// Useful as a placeholder where a padding widget is expected but no
+  /// padding is required.
+  Widget pZero() => Padding(
+        padding: EdgeInsets.zero,
+        child: this,
+      );
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -204,18 +204,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -417,10 +417,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.8"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: playx_core
 description: Core package for playx eco system contains shared classes and utilities.
-version: 1.0.0
+version: 1.0.1
 homepage: https://sourcya.io/
 repository: https://github.com/playx-flutter/playx_core
 issue_tracker: https://github.com/playx-flutter/playx_core/issues

--- a/test/extensions/padding_extensions_test.dart
+++ b/test/extensions/padding_extensions_test.dart
@@ -1,0 +1,223 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playx_core/src/extensions/padding_extensions.dart';
+
+void main() {
+  group('Padding Extensions', () {
+    group('PlayxNumPaddingExtensions', () {
+      group('p', () {
+        test('returns EdgeInsets.all with toDouble value for int', () {
+          expect(16.p, EdgeInsets.all(16));
+        });
+
+        test('returns EdgeInsets.all with toDouble value for double', () {
+          expect(2.5.p, EdgeInsets.all(2.5));
+        });
+
+        test('returns EdgeInsets.all zero for zero', () {
+          expect(0.p, EdgeInsets.zero);
+        });
+      });
+
+      group('px', () {
+        test('returns EdgeInsets.symmetric horizontal with toDouble value', () {
+          expect(8.px, EdgeInsets.symmetric(horizontal: 8));
+        });
+
+        test('returns EdgeInsets.symmetric horizontal for double', () {
+          expect(1.5.px, EdgeInsets.symmetric(horizontal: 1.5));
+        });
+      });
+
+      group('py', () {
+        test('returns EdgeInsets.symmetric vertical with toDouble value', () {
+          expect(4.py, EdgeInsets.symmetric(vertical: 4));
+        });
+
+        test('returns EdgeInsets.symmetric vertical for double', () {
+          expect(0.5.py, EdgeInsets.symmetric(vertical: 0.5));
+        });
+      });
+
+      group('pAll', () {
+        test('returns EdgeInsets.all with toDouble value', () {
+          expect(12.pAll, EdgeInsets.all(12));
+        });
+
+        test('is equivalent to p', () {
+          expect(12.pAll, 12.p);
+        });
+      });
+
+      group('pLR', () {
+        test('returns EdgeInsets.symmetric horizontal with toDouble value', () {
+          expect(10.pLR, EdgeInsets.symmetric(horizontal: 10));
+        });
+
+        test('is equivalent to px', () {
+          expect(10.pLR, 10.px);
+        });
+      });
+
+      group('pTB', () {
+        test('returns EdgeInsets.symmetric vertical with toDouble value', () {
+          expect(6.pTB, EdgeInsets.symmetric(vertical: 6));
+        });
+
+        test('is equivalent to py', () {
+          expect(6.pTB, 6.py);
+        });
+      });
+
+      group('pZero', () {
+        test('returns EdgeInsets.zero ignoring receiver', () {
+          expect(16.pZero, EdgeInsets.zero);
+        });
+
+        test('returns EdgeInsets.zero for zero receiver', () {
+          expect(0.pZero, EdgeInsets.zero);
+        });
+      });
+
+      group('pSymmetric()', () {
+        test('returns EdgeInsets.symmetric with given values', () {
+          expect(
+            0.pSymmetric(horizontal: 12, vertical: 6),
+            EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          );
+        });
+
+        test('defaults to EdgeInsets.zero', () {
+          expect(0.pSymmetric(), EdgeInsets.zero);
+        });
+
+        test('supports only horizontal', () {
+          expect(
+            0.pSymmetric(horizontal: 8),
+            EdgeInsets.symmetric(horizontal: 8),
+          );
+        });
+
+        test('supports only vertical', () {
+          expect(
+            0.pSymmetric(vertical: 8),
+            EdgeInsets.symmetric(vertical: 8),
+          );
+        });
+      });
+
+      group('pOnly()', () {
+        test('returns EdgeInsets.only with given values', () {
+          expect(
+            0.pOnly(left: 10, top: 4, right: 2, bottom: 1),
+            EdgeInsets.only(left: 10, top: 4, right: 2, bottom: 1),
+          );
+        });
+
+        test('defaults to EdgeInsets.zero', () {
+          expect(0.pOnly(), EdgeInsets.zero);
+        });
+
+        test('supports only left', () {
+          expect(0.pOnly(left: 10), EdgeInsets.only(left: 10));
+        });
+
+        test('supports only top', () {
+          expect(0.pOnly(top: 4), EdgeInsets.only(top: 4));
+        });
+      });
+    });
+
+    group('PlayxWidgetPaddingExtensions', () {
+      group('pAll()', () {
+        testWidgets('wraps widget in Padding with EdgeInsets.all',
+            (tester) async {
+          const child = SizedBox();
+          final widget = child.pAll(8);
+
+          await tester.pumpWidget(
+            MaterialApp(home: Scaffold(body: widget)),
+          );
+
+          final padding = tester.widget<Padding>(find.byType(Padding));
+          expect(padding.padding, EdgeInsets.all(8));
+          expect(padding.child, isA<SizedBox>());
+        });
+      });
+
+      group('pSymmetric()', () {
+        testWidgets('wraps widget with given symmetric padding',
+            (tester) async {
+          const child = SizedBox();
+          final widget = child.pSymmetric(horizontal: 12, vertical: 6);
+
+          await tester.pumpWidget(
+            MaterialApp(home: Scaffold(body: widget)),
+          );
+
+          final padding = tester.widget<Padding>(find.byType(Padding));
+          expect(
+            padding.padding,
+            EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          );
+        });
+
+        testWidgets('defaults to EdgeInsets.zero', (tester) async {
+          const child = SizedBox();
+          final widget = child.pSymmetric();
+
+          await tester.pumpWidget(
+            MaterialApp(home: Scaffold(body: widget)),
+          );
+
+          final padding = tester.widget<Padding>(find.byType(Padding));
+          expect(padding.padding, EdgeInsets.zero);
+        });
+      });
+
+      group('pOnly()', () {
+        testWidgets('wraps widget with given per-side padding', (tester) async {
+          const child = SizedBox();
+          final widget = child.pOnly(left: 10, top: 4, right: 2, bottom: 1);
+
+          await tester.pumpWidget(
+            MaterialApp(home: Scaffold(body: widget)),
+          );
+
+          final padding = tester.widget<Padding>(find.byType(Padding));
+          expect(
+            padding.padding,
+            EdgeInsets.only(left: 10, top: 4, right: 2, bottom: 1),
+          );
+        });
+
+        testWidgets('defaults to EdgeInsets.zero', (tester) async {
+          const child = SizedBox();
+          final widget = child.pOnly();
+
+          await tester.pumpWidget(
+            MaterialApp(home: Scaffold(body: widget)),
+          );
+
+          final padding = tester.widget<Padding>(find.byType(Padding));
+          expect(padding.padding, EdgeInsets.zero);
+        });
+      });
+
+      group('pZero()', () {
+        testWidgets('wraps widget with EdgeInsets.zero', (tester) async {
+          const child = SizedBox();
+          final widget = child.pZero();
+
+          await tester.pumpWidget(
+            MaterialApp(home: Scaffold(body: widget)),
+          );
+
+          final padding = tester.widget<Padding>(find.byType(Padding));
+          expect(padding.padding, EdgeInsets.zero);
+          expect(padding.child, isA<SizedBox>());
+        });
+      });
+    });
+  });
+}


### PR DESCRIPTION
…u1cz]

Introduce two extension sets for convenient padding usage:

- PlayxNumPaddingExtensions on num: .p, .px, .py, .pAll, .pLR, .pTB, .pZero, pSymmetric(), pOnly() to create unscaled EdgeInsets from numeric values.

- PlayxWidgetPaddingExtensions on Widget: pAll(), pSymmetric(), pOnly(), pZero() to wrap widgets in Padding with common EdgeInsets patterns.

Also bump version to 1.0.1 and update CHANGELOG.